### PR TITLE
Leaderboard

### DIFF
--- a/src/app/(components)/Leaderboard.tsx
+++ b/src/app/(components)/Leaderboard.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useState, useEffect } from 'react'
+import Link from 'next/link'
 
 const Leaderboard = () => {
   const [proxyParams, setProxyParams] = useState<ProxyCall>({
@@ -53,7 +54,9 @@ const Leaderboard = () => {
                 return (
                   <tr className="bg-white border-b dark:bg-gray-800 dark:border-gray-700" key={leader.brawlhalla_id}>
                     <th scope="row" className="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white">
-                      {leader.name}
+                      <Link href={`/player/${leader.brawlhalla_id}`}>
+                        {leader.name}
+                      </Link>
                     </th>
                     <td className="px-6 py-4">
                       {leader.region}  

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ const Home = () => {
   const router = useRouter()
   return (
     <main className="flex flex-col items-center">
-      <section>
+      <section className='p-8'>
         Check out all available Legends and their stats! <br/>
         <button 
           onClick={() => router.push('/legends')}
@@ -16,7 +16,7 @@ const Home = () => {
           Legends
         </button>
       </section>
-      <section>
+      <section className='p-8'>
         <Leaderboard />
       </section>
     </main>

--- a/src/app/player/[id]/page.tsx
+++ b/src/app/player/[id]/page.tsx
@@ -19,10 +19,8 @@ const Stats = ({ params }: IdParams) => {
       headers: {
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify({
-        data: proxyParams
-      },
-    )})
+      body: JSON.stringify(proxyParams),
+    })
     .then(res => res.json())
     .then(data => {
       setPlayer(data['player'])


### PR DESCRIPTION
- Fixed formatting for body of player page API call
- Players' names on leaderboard now link to their corresponding `/player/<id>` route
- Added padding to main page components